### PR TITLE
export all symbols for moonp binary

### DIFF
--- a/makefile
+++ b/makefile
@@ -268,7 +268,7 @@ all: $(BIN_PATH)/$(BIN_NAME)
 $(BIN_PATH)/$(BIN_NAME): $(OBJECTS)
 	@echo "Linking: $@"
 	@$(START_TIME)
-	$(CMD_PREFIX)$(CXX) $(OBJECTS) $(LDFLAGS) -o $@
+	$(CMD_PREFIX)$(CXX) $(OBJECTS) $(LDFLAGS) -o $@ -Wl,-E
 	@echo -en "\t Link time: "
 	@$(END_TIME)
 


### PR DESCRIPTION
Current `moonp` binary doesn't export the lua symbols, which makes requiring C modules that do not include their own lua library (which they shouldn't) fail. This can be repro'd by trying to require lpeg from `moonp -e` or the moonp repl.

This PR fixes this by exporting all symbols for the `moonp` binary. I'm not sure we actually want to export *all* the symbols, but afaik this doesn't cause issues and fixes the current issue. This can be changed by using a linker version script.